### PR TITLE
[Legacy PR #24] Support for displaying a trend line and embedding a right image (by @rahul-deepsource)

### DIFF
--- a/pybadges/__init__.py
+++ b/pybadges/__init__.py
@@ -40,9 +40,13 @@ import jinja2
 import requests
 
 from pybadges import text_measurer
-from pybadges.trend import trend
 from pybadges import precalculated_text_measurer
 from pybadges.version import __version__
+
+try:
+    from pybadges.trend import trend
+except:
+    trend = None
 
 _JINJA2_ENVIRONMENT = jinja2.Environment(
     trim_blocks=True,
@@ -183,7 +187,8 @@ def badge(
             itself and saves an additional HTTP request. See embed_logo.
         show_trend: accepts comma separated integers (least to most recent), and plots a
             trend line showing variation of that data. If both show_trend and right_image
-            are passed, ValueError is raised.
+            are passed, ValueError is raised. Needs additional dependencies installed:
+            numpy and drawSvg.
         trend_color: color of the trend line. If not supplied, right_color is used.
         trend_width: stroke width of the trend line.
     """
@@ -199,6 +204,9 @@ def badge(
         raise ValueError('right-image and trend cannot be used together.')
 
     if show_trend:
+        if trend is None:
+            raise ValueError('Additional dependencies not installed.')
+
         right_image = trend(
             samples=show_trend,
             stroke_color=(trend_color or right_color),

--- a/pybadges/__init__.py
+++ b/pybadges/__init__.py
@@ -119,13 +119,16 @@ def badge(
     right_link: Optional[str] = None,
     whole_link: Optional[str] = None,
     logo: Optional[str] = None,
-    left_color: str = '#555',
+    bg_color: str = '#555',
+    left_color: Optional[str] = None,
     right_color: str = '#007ec6',
     measurer: Optional[text_measurer.TextMeasurer] = None,
     embed_logo: bool = False,
     whole_title: Optional[str] = None,
     left_title: Optional[str] = None,
     right_title: Optional[str] = None,
+    right_image: Optional[str] = None,
+    embed_right_image: bool = False,
 ) -> str:
     """Creates a github-style badge as an SVG image.
 
@@ -148,16 +151,13 @@ def badge(
             selected. If set then left_link and right_right may not be set.
         logo: A url representing a logo that will be displayed inside the
             badge. Can be a data URL e.g. "data:image/svg+xml;utf8,<svg..."
-        left_color: The color of the part of the badge containing the left-hand
-            text. Can be an valid CSS color
+        bg_color: The background color of the badge. Can be an valid CSS color
             (see https://developer.mozilla.org/en-US/docs/Web/CSS/color) or a
             color name defined here:
             https://github.com/badges/shields/blob/master/lib/colorscheme.json
+        left_color: The color of the part of the badge containing the left text. If not specified, bg_color is used
         right_color: The color of the part of the badge containing the
-            right-hand text. Can be an valid CSS color
-            (see https://developer.mozilla.org/en-US/docs/Web/CSS/color) or a
-            color name defined here:
-            https://github.com/badges/shields/blob/master/lib/colorscheme.json
+            right-hand text.
         measurer: A text_measurer.TextMeasurer that can be used to measure the
             width of left_text and right_text.
         embed_logo: If True then embed the logo image directly in the badge.
@@ -173,6 +173,10 @@ def badge(
         right_title: The title attribute to associate with the right part of
             the badge.
             See https://developer.mozilla.org/en-US/docs/Web/SVG/Element/title.
+        right_image: A url representing a image which can be embedded before right_text.
+            Can be a data URL e.g. "data:image/svg+xml;utf8,<svg..."
+        embed_right_image: If True, the right image is embedded into the badge
+            itself and saves an additional HTTP request. See embed_logo.
     """
     if measurer is None:
         measurer = (
@@ -186,6 +190,9 @@ def badge(
     if logo and embed_logo:
         logo = _embed_image(logo)
 
+    if right_image and embed_right_image:
+        right_image = _embed_image(right_image)
+
     svg = template.render(
         left_text=left_text,
         right_text=right_text,
@@ -195,11 +202,13 @@ def badge(
         right_link=right_link,
         whole_link=whole_link,
         logo=logo,
+        bg_color=_NAME_TO_COLOR.get(bg_color, bg_color),
         left_color=_NAME_TO_COLOR.get(left_color, left_color),
         right_color=_NAME_TO_COLOR.get(right_color, right_color),
         whole_title=whole_title,
         left_title=left_title,
         right_title=right_title,
+        right_image=right_image,
     )
     xml = minidom.parseString(svg)
     _remove_blanks(xml)

--- a/pybadges/__init__.py
+++ b/pybadges/__init__.py
@@ -155,13 +155,13 @@ def badge(
             selected. If set then left_link and right_right may not be set.
         logo: A url representing a logo that will be displayed inside the
             badge. Can be a data URL e.g. "data:image/svg+xml;utf8,<svg..."
-        bg_color: The background color of the badge. Can be an valid CSS color
+        bg_color: The background color of the badge. Default: #555. Can be an valid CSS color
             (see https://developer.mozilla.org/en-US/docs/Web/CSS/color) or a
             color name defined here:
             https://github.com/badges/shields/blob/master/lib/colorscheme.json
         left_color: The color of the part of the badge containing the left text. If not specified, bg_color is used
         right_color: The color of the part of the badge containing the
-            right-hand text.
+            right-hand text. Default: #007ec6 (blue)
         measurer: A text_measurer.TextMeasurer that can be used to measure the
             width of left_text and right_text.
         embed_logo: If True then embed the logo image directly in the badge.
@@ -181,8 +181,9 @@ def badge(
             Can be a data URL e.g. "data:image/svg+xml;utf8,<svg..."
         embed_right_image: If True, the right image is embedded into the badge
             itself and saves an additional HTTP request. See embed_logo.
-        show_trend: plot a trend with not more than 10 data points passed. if both
-            show_trend and right_image are passed, ValueError is raised.
+        show_trend: accepts comma separated integers (least to most recent), and plots a
+            trend line showing variation of that data. If both show_trend and right_image
+            are passed, ValueError is raised.
         trend_color: color of the trend line. If not supplied, right_color is used.
         trend_width: stroke width of the trend line.
     """

--- a/pybadges/__init__.py
+++ b/pybadges/__init__.py
@@ -199,11 +199,8 @@ def badge(
         raise ValueError('right-image and trend cannot be used together.')
 
     if show_trend:
-        samples = show_trend if len(show_trend) <= 10 else show_trend[:10]
-        if len(samples) < 10:
-            samples = [0] * (10 - len(samples)) + samples
         right_image = trend(
-            samples=samples,
+            samples=show_trend,
             stroke_color=(trend_color or right_color),
             stroke_width=trend_width,
         )

--- a/pybadges/__main__.py
+++ b/pybadges/__main__.py
@@ -23,7 +23,6 @@ import tempfile
 import webbrowser
 
 import pybadges
-from pybadges.trend import trend
 from pybadges.version import __version__
 
 
@@ -161,18 +160,6 @@ def main():
               file=sys.stderr)
         sys.exit(1)
 
-    right_image = args.right_image
-    if args.show_trend:
-        samples = args.show_trend if len(
-            args.show_trend) < 10 else args.show_trend[:10]
-        if len(samples) < 10:
-            samples = [0] * (10 - len(samples)) + samples
-        right_image = trend(
-            samples=samples,
-            stroke_color=(args.trend_color or args.right_color),
-            stroke_width=args.trend_width,
-        )
-
     measurer = None
     if args.use_pil_text_measurer:
         if args.deja_vu_sans_path is None:
@@ -198,8 +185,11 @@ def main():
         whole_title=args.whole_title,
         left_title=args.left_title,
         right_title=args.right_title,
-        right_image=right_image,
+        right_image=args.right_image,
         embed_right_image=args.embed_right_image,
+        show_trend=args.show_trend,
+        trend_color=args.trend_color,
+        trend_width=args.trend_width,
     )
 
     if args.browser:

--- a/pybadges/__main__.py
+++ b/pybadges/__main__.py
@@ -60,7 +60,7 @@ def main():
         'clicked')
     parser.add_argument('--bg-color',
                         default='#555',
-                        help='the background color of the badge')
+                        help='the background color of the badge. Default: #555')
     parser.add_argument(
         '--left-color',
         default='None',
@@ -69,7 +69,8 @@ def main():
     parser.add_argument(
         '--right-color',
         default='#007ec6',
-        help='the background color of the right-hand-side of the badge')
+        help='the background color of the right-hand-side of the badge.'
+        ' Default: #007ec6')
     parser.add_argument(
         '--logo',
         default=None,
@@ -132,8 +133,10 @@ def main():
         '--show-trend',
         default=None,
         type=csv,
-        help='up to ten integral values to be plotted as a trend. If'
-        ' --show-trend is passed, right image should not be used.')
+        help='accepts comma separated integers (least to most recent) and'
+        ' plots a trend line showing variation of that data. If both'
+        ' --show-trend is passed, right image should not be used. It needs'
+        ' additional dependencies installed: drawSvg and numpy.')
     parser.add_argument(
         '--trend-color',
         default=None,
@@ -156,7 +159,7 @@ def main():
               file=sys.stderr)
         sys.exit(1)
     if args.show_trend and args.right_image:
-        print('argument --right-image: cannot be used with ' + '--show-trend',
+        print('argument --right-image: cannot be used with --show-trend',
               file=sys.stderr)
         sys.exit(1)
 

--- a/pybadges/__main__.py
+++ b/pybadges/__main__.py
@@ -28,10 +28,13 @@ from pybadges.version import __version__
 
 
 def main():
+
     def csv(values):
         return [int(value) for value in values.split(",")]
+
     def boolean(value):
         return value.lower() in ['y', 'yes', 't', 'true', '1', '']
+
     parser = argparse.ArgumentParser(
         'pybadges',
         description='generate a github-style badge given some text and colors')
@@ -56,10 +59,9 @@ def main():
         default=None,
         help='the url to redirect to when the right-hand of the badge is ' +
         'clicked')
-    parser.add_argument(
-        '--bg-color',
-        default='#555',
-        help='the background color of the badge')
+    parser.add_argument('--bg-color',
+                        default='#555',
+                        help='the background color of the badge')
     parser.add_argument(
         '--left-color',
         default='None',
@@ -93,7 +95,8 @@ def main():
         type=boolean,
         const='yes',
         default='no',
-        help='embed right image into the badge. See embed-logo for more details')
+        help='embed right image into the badge. See embed-logo for more details'
+    )
     parser.add_argument('--browser',
                         action='store_true',
                         default=False,
@@ -137,11 +140,10 @@ def main():
         default=None,
         help='the color of the trend-line. if not supplied, it is plotted'
         ' in the same color as right-color')
-    parser.add_argument(
-        '--trend-width',
-        type=int,
-        default=1,
-        help='the width of the trend-line. default: 1')
+    parser.add_argument('--trend-width',
+                        type=int,
+                        default=1,
+                        help='the width of the trend-line. default: 1')
     parser.add_argument(
         '-v',
         '--version',
@@ -155,14 +157,14 @@ def main():
               file=sys.stderr)
         sys.exit(1)
     if args.show_trend and args.right_image:
-        print('argument --right-image: cannot be used with ' +
-              '--show-trend',
+        print('argument --right-image: cannot be used with ' + '--show-trend',
               file=sys.stderr)
         sys.exit(1)
 
     right_image = args.right_image
     if args.show_trend:
-        samples = args.show_trend if len(args.show_trend) < 10 else args.show_trend[:10]
+        samples = args.show_trend if len(
+            args.show_trend) < 10 else args.show_trend[:10]
         if len(samples) < 10:
             samples = [0] * (10 - len(samples)) + samples
         right_image = trend(
@@ -181,23 +183,24 @@ def main():
         from pybadges import pil_text_measurer
         measurer = pil_text_measurer.PilMeasurer(args.deja_vu_sans_path)
 
-    badge = pybadges.badge(left_text=args.left_text,
-                           right_text=args.right_text,
-                           left_link=args.left_link,
-                           right_link=args.right_link,
-                           whole_link=args.whole_link,
-                           bg_color=args.bg_color,
-                           left_color=args.left_color,
-                           right_color=args.right_color,
-                           logo=args.logo,
-                           measurer=measurer,
-                           embed_logo=args.embed_logo,
-                           whole_title=args.whole_title,
-                           left_title=args.left_title,
-                           right_title=args.right_title,
-                           right_image=right_image,
-                           embed_right_image=args.embed_right_image,
-           )
+    badge = pybadges.badge(
+        left_text=args.left_text,
+        right_text=args.right_text,
+        left_link=args.left_link,
+        right_link=args.right_link,
+        whole_link=args.whole_link,
+        bg_color=args.bg_color,
+        left_color=args.left_color,
+        right_color=args.right_color,
+        logo=args.logo,
+        measurer=measurer,
+        embed_logo=args.embed_logo,
+        whole_title=args.whole_title,
+        left_title=args.left_title,
+        right_title=args.right_title,
+        right_image=right_image,
+        embed_right_image=args.embed_right_image,
+    )
 
     if args.browser:
         _, badge_path = tempfile.mkstemp(suffix='.svg')

--- a/pybadges/badge-template-full.svg
+++ b/pybadges/badge-template-full.svg
@@ -1,6 +1,7 @@
 {% set logo_width = 14 if logo else 0 %}
 {% set logo_padding = 3 if (logo and left_text) else 0 %}
-{% set left_width = left_text_width + 10 + logo_width + logo_padding %}
+{% set image_width = 110 if right_image else 0 %}
+{% set left_width = image_width + left_text_width + 10 + logo_width + logo_padding %}
 {% set right_width = right_text_width + 10 %}
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="{{ left_width + right_width }}" height="20">
   {% if whole_title %}
@@ -16,7 +17,7 @@
   </clipPath>
 
   <g clip-path="url(#round)">
-    <rect width="{{ left_width }}" height="20" fill="{{ left_color }}">
+    <rect width="{{ left_width }}" height="20" fill="{{ bg_color }}">
       {% if left_title %}
         <title>{{ left_title }}</title>
       {% endif %}
@@ -26,20 +27,26 @@
         <title>{{ right_title }}</title>
       {% endif %}
     </rect>
+    {% if left_color %}
+        <rect x="{{ logo_width + 2*logo_padding }}" width="{{ left_text_width + 7 }}" height="20" fill="{{ left_color }}"/>
+    {% endif %}
     <rect width="{{ left_width + right_width }}" height="20" fill="url(#smooth)"/>
   </g>
 
   <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="110">
     {% if logo %}
-      <image x="5" y="3" width="{{ logo_width}}" height="14" xlink:href="{{ logo}}"/>
+      <image x="{{ logo_padding }}" y="3" width="{{ logo_width }}" height="14" xlink:href="{{ logo }}"/>
     {% endif %}
-    <text x="{{ (((left_width+logo_width+logo_padding)/2)+1)*10 }}" y="150" fill="#010101" fill-opacity=".3" transform="scale(0.1)" textLength="{{ (left_width-(10+logo_width+logo_padding))*10 }}" lengthAdjust="spacing">{{ left_text }}</text>
-    <text x="{{ (((left_width+logo_width+logo_padding)/2)+1)*10 }}" y="140" transform="scale(0.1)" textLength="{{ (left_width-(10+logo_width+logo_padding))*10 }}" lengthAdjust="spacing">{{ left_text }}</text>
+    <text x="{{ (((left_width+logo_width+logo_padding-image_width)/2)+1)*10 }}" y="150" fill="#010101" fill-opacity=".3" transform="scale(0.1)" textLength="{{ (left_width-(10+logo_width+logo_padding+image_width))*10 }}" lengthAdjust="spacing">{{ left_text }}</text>
+    <text x="{{ (((left_width+logo_width+logo_padding-image_width)/2)+1)*10 }}" y="140" transform="scale(0.1)" textLength="{{ (left_width-(10+logo_width+logo_padding+image_width))*10 }}" lengthAdjust="spacing">{{ left_text }}</text>
+    {% if right_image %}
+      <image x="{{ left_width-image_width }}" y="3" width="{{ image_width }}" height="14" xlink:href="{{ right_image }}"/>
+    {% endif %}
     <text x="{{ (left_width+right_width/2-1)*10 }}" y="150" fill="#010101" fill-opacity=".3" transform="scale(0.1)" textLength="{{ (right_width-10)*10 }}" lengthAdjust="spacing">{{ right_text }}</text>
     <text x="{{ (left_width+right_width/2-1)*10 }}" y="140" transform="scale(0.1)" textLength="{{ (right_width-10)*10 }}" lengthAdjust="spacing">{{ right_text}}</text>
 
   {% if left_link or whole_link %}
-    <a xlink:href="{{ left_link or wholelink }}">
+    <a xlink:href="{{ left_link or whole_link }}">
       <rect width="{{ left_width }}" height="20" fill="rgba(0,0,0,0)"/>
     </a>
   {% endif %}

--- a/pybadges/badge-template-full.svg
+++ b/pybadges/badge-template-full.svg
@@ -1,6 +1,6 @@
 {% set logo_width = 14 if logo else 0 %}
 {% set logo_padding = 3 if (logo and left_text) else 0 %}
-{% set image_width = 110 if right_image else 0 %}
+{% set image_width = 107 if right_image else 0 %}
 {% set left_width = image_width + left_text_width + 10 + logo_width + logo_padding %}
 {% set right_width = right_text_width + 10 %}
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="{{ left_width + right_width }}" height="20">

--- a/pybadges/trend.py
+++ b/pybadges/trend.py
@@ -1,13 +1,12 @@
 from typing import Optional, List, Tuple
 
 import drawSvg as draw
-import itertools
 import numpy as np
 
 import pybadges
 
 HEIGHT = 13
-WIDTH = 110
+WIDTH = 107
 X_OFFSET = 7
 Y_OFFSET = 1
 
@@ -19,23 +18,11 @@ def normalize(arr: np.ndarray) -> np.ndarray:
     return arr
 
 
-def repeat(samples: List[int], n: int) -> List[int]:
-    """Repeats a value n times in an array.
-
-    Args:
-        samples: The list of all elements to be repeated.
-        n: Number of times to repeat each element in samples.
-    """
-    return list(
-        itertools.chain.from_iterable(
-            itertools.repeat(sample, n) for sample in samples))
-
-
 def fit_data(samples: List[int]) -> Tuple[List[int], List[int]]:
-    y = list(
-        itertools.chain.from_iterable(
-            itertools.repeat(sample, 10) for sample in samples))
-    xp = np.arange(len(y))
+    width = WIDTH - X_OFFSET
+    N = int(width / len(samples))
+    y = np.repeat(samples, N)
+    xp = np.linspace(start=X_OFFSET, stop=width, num=len(y))
     yp = normalize(np.poly1d(np.polyfit(xp, y, 15))(xp))
     yp[yp > 0] *= (HEIGHT - 2)
     return xp, yp
@@ -51,9 +38,9 @@ def trend(samples: List[int], stroke_color: str, stroke_width: int) -> str:
     )
 
     xp, yp = fit_data(samples)
-    path.M(X_OFFSET + xp[0], yp[0])
+    path.M(xp[0], yp[0])
     for x, y in zip(xp[1:], yp[1:]):
-        path.L(X_OFFSET + x, y)
+        path.L(x, y)
     canvas.append(path)
 
     return canvas.asDataUri()

--- a/pybadges/trend.py
+++ b/pybadges/trend.py
@@ -28,28 +28,20 @@ def repeat(samples: List[int], n: int) -> List[int]:
     """
     return list(
         itertools.chain.from_iterable(
-            itertools.repeat(sample, n)
-            for sample in samples
-        )
-    )
+            itertools.repeat(sample, n) for sample in samples))
 
 
 def fit_data(samples: List[int]) -> Tuple[List[int], List[int]]:
     y = list(
-            itertools.chain.from_iterable(
-                itertools.repeat(sample, 10)
-                for sample in samples
-            )
-        )
+        itertools.chain.from_iterable(
+            itertools.repeat(sample, 10) for sample in samples))
     xp = np.arange(len(y))
     yp = normalize(np.poly1d(np.polyfit(xp, y, 15))(xp))
-    yp[yp>0] *= (HEIGHT-2)
+    yp[yp > 0] *= (HEIGHT - 2)
     return xp, yp
 
 
-def trend(
-        samples: List[int], stroke_color: str, stroke_width: int
-    ) -> str:
+def trend(samples: List[int], stroke_color: str, stroke_width: int) -> str:
     canvas = draw.Drawing(WIDTH, HEIGHT, origin=(0, -Y_OFFSET))
     path = draw.Path(
         fill="transparent",

--- a/pybadges/trend.py
+++ b/pybadges/trend.py
@@ -1,0 +1,67 @@
+from typing import Optional, List, Tuple
+
+import drawSvg as draw
+import itertools
+import numpy as np
+
+import pybadges
+
+HEIGHT = 13
+WIDTH = 110
+X_OFFSET = 7
+Y_OFFSET = 1
+
+
+def normalize(arr: np.ndarray) -> np.ndarray:
+    max_arr = np.max(arr)
+    if max_arr != 0:
+        arr /= max_arr
+    return arr
+
+
+def repeat(samples: List[int], n: int) -> List[int]:
+    """Repeats a value n times in an array.
+
+    Args:
+        samples: The list of all elements to be repeated.
+        n: Number of times to repeat each element in samples.
+    """
+    return list(
+        itertools.chain.from_iterable(
+            itertools.repeat(sample, n)
+            for sample in samples
+        )
+    )
+
+
+def fit_data(samples: List[int]) -> Tuple[List[int], List[int]]:
+    y = list(
+            itertools.chain.from_iterable(
+                itertools.repeat(sample, 10)
+                for sample in samples
+            )
+        )
+    xp = np.arange(len(y))
+    yp = normalize(np.poly1d(np.polyfit(xp, y, 15))(xp))
+    yp[yp>0] *= (HEIGHT-2)
+    return xp, yp
+
+
+def trend(
+        samples: List[int], stroke_color: str, stroke_width: int
+    ) -> str:
+    canvas = draw.Drawing(WIDTH, HEIGHT, origin=(0, -Y_OFFSET))
+    path = draw.Path(
+        fill="transparent",
+        stroke=pybadges._NAME_TO_COLOR.get(stroke_color, stroke_color),
+        stroke_width=stroke_width,
+        stroke_linejoin="round",
+    )
+
+    xp, yp = fit_data(samples)
+    path.M(X_OFFSET + xp[0], yp[0])
+    for x, y in zip(xp[1:], yp[1:]):
+        path.L(X_OFFSET + x, y)
+    canvas.append(path)
+
+    return canvas.asDataUri()

--- a/setup.py
+++ b/setup.py
@@ -69,6 +69,7 @@ setup(
     install_requires=['Jinja2>=2.9.0,<3', 'requests>=2.9.0,<3'],
     extras_require={
         'pil-measurement': ['Pillow>=5,<6'],
+        'trend': ['numpy', 'drawSvg'],
         'dev': [
             'fonttools>=3.26', 'nox', 'Pillow>=5', 'pytest>=3.6', 'xmldiff>=2.4'
         ],

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ setup(
     install_requires=['Jinja2>=2.9.0,<3', 'requests>=2.9.0,<3'],
     extras_require={
         'pil-measurement': ['Pillow>=5,<6'],
-        'trend': ['numpy', 'drawSvg'],
+        'trend': ['drawsvg>=1.6.0', 'numpy>=1.19.0'],
         'dev': [
             'fonttools>=3.26', 'nox', 'Pillow>=5', 'pytest>=3.6', 'xmldiff>=2.4'
         ],

--- a/tests/test-badges.json
+++ b/tests/test-badges.json
@@ -29,7 +29,7 @@
     "file_name": "complete.svg",
     "left_text": "complete",
     "right_text": "example",
-    "left_color": "green",
+    "bg_color": "green",
     "right_color": "#fb3",
     "left_link": "http://www.complete.com/",
     "right_link": "http://www.example.com",
@@ -43,7 +43,7 @@
     "file_name": "complete.svg",
     "left_text": "complete",
     "right_text": "example",
-    "left_color": "green",
+    "bg_color": "green",
     "right_color": "#fb3",
     "left_link": "http://www.complete.com/",
     "right_link": "http://www.example.com",
@@ -121,7 +121,7 @@
     "file_name": "tests.svg",
     "left_text": "tests",
     "right_text": "231 passed, 1 failed, 1 skipped",
-    "left_color": "blue",
+    "bg_color": "blue",
     "right_color": "orange"
   }
 ]


### PR DESCRIPTION
**Original Author:** [@rahul-deepsource](https://github.com/rahul-deepsource)
**Original PR:** https://github.com/google/pybadges/pull/24

---

Thanks for the wonderful library!

I wanted to add the functionality to add a trend line which can graphically show how a metric has been varying over time, and thought that this would be a nice addition to this library as well!

Here are a bunch of changes:

- Add `show-trend` argument which takes in comma-separated list of values (maximum: 10).
- Add `--right-image` which would display an image (110 x 14) between left and right text.
- Rename `--left-color` to `--bg-color` because this was also the background for the `right_image`, so it didn't really make sense to call it `left-color`.
- Add a new `left-color` which would add a 

Here is an example: ![](https://gist.githubusercontent.com/rahul-deepsource/85b466baf2d9a7fb0e3c7db2f17ebfbe/raw/afb7a3d6d50930c84587d01052ee3893c76564c3/increasing_trend.svg)

which was generated using the command:

```
python -m pybadges --left-text "badge trends" --right-text "2.1k" --whole-link "https://deepsource.io/gh/deepsourcelabs/asgard" --bg-color "#252525" --right-color "#63B439" --logo https://raw.githubusercontent.com/deepsourcelabs/brand-assets/master/logo-white.svg --show-trend 1311,2100,3333,598,800,1111,200 --left-color="#4E4E4E" --embed-logo
```

There are still a few tests failing (and docs missing). If you give me a green flag that you intend to merge these changes, I'd be happy to provide them as well! :)