### PR TITLE
[Legacy PR #45] Replaced depreciated pkg_resources with importlib.resources in precalculated_text_measurer.py for Python 3.12 support (by @ashrobertsdragon)

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -45,8 +45,8 @@ def unit(session):
     'install',
     [
         'Jinja2==3.0.0',
-        'Pillow==8.3.2',  # Oldest version that supports Python 3.7 to 3.10.
-        'requests==2.22.0',
+        'Pillow==10.1',  # Oldest version that supports Python 3.12.
+        'requests==2.32.3',  # Oldest version that supports Python 3.12
         'xmldiff==2.4'
     ])
 def compatibility(session, install):

--- a/noxfile.py
+++ b/noxfile.py
@@ -47,7 +47,7 @@ def unit(session):
         'Jinja2==3.0.0',
         'Pillow==10.1',  # Oldest version that supports Python 3.12.
         'requests==2.32.3',  # Oldest version that supports Python 3.12
-        'xmldiff==2.4'
+        'xmldiff==2.6' # Oldest version that supports Python 3.12
     ])
 def compatibility(session, install):
     """Run the unit test suite with each support library and Python version."""

--- a/pybadges/precalculated_text_measurer.py
+++ b/pybadges/precalculated_text_measurer.py
@@ -18,7 +18,7 @@ Uses a precalculated set of metrics to calculate the string length.
 
 import io
 import json
-import pkg_resources
+import importlib.resources as resources
 from typing import cast, Mapping, TextIO, Type
 
 from pybadges import text_measurer
@@ -74,19 +74,23 @@ class PrecalculatedTextMeasurer(text_measurer.TextMeasurer):
         if cls._default_cache is not None:
             return cls._default_cache
 
-        if pkg_resources.resource_exists(__name__, 'default-widths.json.xz'):
+        resource_name_xz = 'default-widths.json.xz'
+        resource_name_json = 'default-widths.json'
+
+        resource_package = resources.files(__name__)
+        resource_xz_path = resource_package / resource_name_xz
+        resource_json_path = resource_package / resource_name_json
+
+        if resource_xz_path.exists():
             import lzma
-            with pkg_resources.resource_stream(__name__,
-                                               'default-widths.json.xz') as f:
-                with lzma.open(f, "rt") as g:
-                    cls._default_cache = PrecalculatedTextMeasurer.from_json(
-                        cast(TextIO, g))
+            with resources.as_file(resource_xz_path) as path:
+                with lzma.open(path, "rt") as f:
+                    cls._default_cache = PrecalculatedTextMeasurer.from_json(cast(TextIO, f))
                     return cls._default_cache
-        elif pkg_resources.resource_exists(__name__, 'default-widths.json'):
-            with pkg_resources.resource_stream(__name__,
-                                               'default-widths.json') as f:
-                cls._default_cache = PrecalculatedTextMeasurer.from_json(
-                    io.TextIOWrapper(f, encoding='utf-8'))
-                return cls._default_cache
+        elif resource_json_path.exists():
+            with resources.as_file(resource_json_path) as path:
+                with open(path, 'r', encoding='utf-8') as f:
+                    cls._default_cache = PrecalculatedTextMeasurer.from_json(f)
+                    return cls._default_cache
         else:
             raise ValueError('could not load default-widths.json')

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,6 @@ setup(
         'License :: OSI Approved :: Apache Software License',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
@@ -67,10 +66,10 @@ setup(
     },
     long_description=get_long_description(),
     long_description_content_type='text/markdown',
-    python_requires='>=3.4',
-    install_requires=['Jinja2>=3,<4', 'requests>=2.22.0,<3'],
+    python_requires='>=3.8',
+    install_requires=['Jinja2>=3,<4', 'requests>=2.32.3,<3'],
     extras_require={
-        'pil-measurement': ['Pillow>=6,<10'],
+        'pil-measurement': ['Pillow>=10.1'],
         'dev': [
             'Flask>=2.0',  # For server tests. 
             'fonttools>=3.26',

--- a/setup.py
+++ b/setup.py
@@ -71,12 +71,12 @@ setup(
     extras_require={
         'pil-measurement': ['Pillow>=10.1'],
         'dev': [
-            'Flask>=2.0',  # For server tests. 
+            'Flask>=2.0',  # For server tests.
             'fonttools>=3.26',
             'nox',
             'Pillow>=5',
             'pytest>=3.6',
-            'xmldiff>=2.4'
+            'xmldiff>=2.6'
         ],
     },
     license='Apache-2.0',


### PR DESCRIPTION
**Original Author:** [@ashrobertsdragon](https://github.com/ashrobertsdragon)
**Original PR:** https://github.com/google/pybadges/pull/45

---

I had the same issue as  issue #44 [pkg_resources is not available by default in Python 3.12](https://github.com/google/pybadges/issues/44). The library pkg_resources was removed from Python in version 3.12 and users are directed to use the resources module in importlib instead. The code is a little different because the methods `resource_exists` doesn't exist in importlub.resources but naming a files object and then checking to see if it exists seems to do the trick.

I have also had to update Pillow to 10.1 and requests to 2.32.3 as these are the oldest (non-yanked in the case of requests) versions that support Python 3.12. Unfortunately, these versions remove support for Python 3.7, so I also updated the minimum version to 3.8 (the python_requires line of setup.py was still set at 3.4). I also updated xmldiff to version 2.6, also the oldest version to support Python 3.12. nox passed with the xmldiff 2.4, but with warnings.

Note: as is, this version will not support Python 3.13 when it is released. nox provided the following depreciation warning:
pybadges\__init__.py:33: DeprecationWarning: 'imghdr' is deprecated and slated for removal in Python 3.13

This is my first pull request aside for the one I accidentally opened on my own repo, but I've read a few others. I have read and followed the contributing guidelines and code of conduct. I have run nox on this branch. It passed all the tests it could run on my machine (type_check is not supported on Windows). I have submitted the required Contributer's License Agreement.